### PR TITLE
Add hex view for transaction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,9 +1760,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1778,11 +1775,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2303,9 +2300,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2835,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14dba8247a6a15b7fdbc7d389e2e6f03ee9f184f87117706d509c092dfe846"
+checksum = "ee025287c0188d75ae2563bcb91c9b0d1843cfc56e4bd3ab867597971b5cc256"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -3062,9 +3059,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "blocktop"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ futures = "0.3.31"
 log = "0.4.22"
 pretty_env_logger = "0.5.0"
 r2d2 = "0.8.10"
-r2d2_sqlite = "0.25.0"
+r2d2_sqlite = "0.26.0"
 ratatui = "0.29.0"
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { version = "0.33.0", features = ["bundled"] }
 timeago = "0.4.2"
 tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
 url = "2.5.4"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -214,3 +214,13 @@ pub fn to_ether(x: U256) -> f64 {
 pub fn useful_gas_price(tx: &Transaction) -> u128 {
     tx.max_fee_per_gas()
 }
+
+pub fn grab_range(xs: &Bytes, a: usize, b: usize) -> Bytes {
+    if a >= xs.len() {
+        Bytes::from(vec![])
+    } else if b > xs.len() {
+        Bytes::from(xs[a..xs.len()].to_vec())
+    } else {
+        Bytes::from(xs[a..b].to_vec())
+    }
+}


### PR DESCRIPTION
# Issue
Closes #9.

# Changes

 - Add bordered hexdump to the transactions detail view containing the transaction's input data

![2025-01-20-122137_1920x1200_scrot](https://github.com/user-attachments/assets/ea64a66f-3cea-4c61-b5b9-275bc6f999be)
