### PR TITLE
Add ^C handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The default invocation (i.e., `blocktop`) will open the TUI and start retrieving
 | --- | --- |
 | `j`, `k`, `Up`, `Down` | Scrolls lists | 
 | `e` | In block or transaction view, opens the block or transaction in [Etherscan](https://etherscan.io), respectively |
-| `q` | Exits the application |
+| `q`, `Ctrl+c` | Exits the application |
 | `Esc` | Returns to the previous page or exits the application if on the main page |
 | `r` | Toggles the address display mode (i.e., labelled or raw) |
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -87,6 +87,10 @@ impl App {
         }
     }
 
+    pub fn on_quit(&mut self) {
+        self.should_quit = true
+    }
+
     pub fn on_esc(&mut self) {
         match self.view {
             View::Default => self.should_quit = true,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use app::App;
-use crossterm::event::{self, Event, KeyCode};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::DefaultTerminal;
 
 use crate::db::Database;
@@ -39,6 +39,11 @@ pub fn run(mut terminal: DefaultTerminal, db: &Database) -> eyre::Result<()> {
                     KeyCode::Down | KeyCode::Char('j') => app.on_down(),
                     KeyCode::Enter => app.on_enter(),
                     KeyCode::Esc => app.on_esc(),
+                    KeyCode::Char('c')
+                        if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                    {
+                        app.on_quit()
+                    }
                     KeyCode::Char(c) => app.on_key(c),
                     _ => {}
                 }


### PR DESCRIPTION
I experimented with `kill` to find that all three of these commands will end the process:
```bash
kill -s SIGINT $(pidof target/release/blocktop)
kill -s SIGTERM $(pidof target/release/blocktop)
kill -s SIGHUP $(pidof target/release/blocktop)
```

This leads me to think that something in ratatui/crossterm is catching the <kbd>^C</kbd> input to make it available as an event, which makes sense, some programs (notoriously `vim`) don't exit on <kbd>^C</kbd>.

Given that, I think it makes sense to just handle this as a keyboard input which triggers a graceful shut down.

Closes https://github.com/jmcph4/blocktop/issues/11