### PR TITLE
Fix timestamp bug for arbitrary transactions

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -88,6 +88,24 @@ impl Database {
         }
     }
 
+    pub fn block_by_transaction_hash(
+        &self,
+        hash: TxHash,
+    ) -> eyre::Result<Option<Block>> {
+        debug!(
+            "Associated block for transaction {} requested from database...",
+            hash
+        );
+
+        match self.transaction(hash)? {
+            Some(tx) => match tx.block_hash {
+                Some(block_hash) => self.block_by_hash(block_hash),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
     /// Retrieve the [`Block`] with the highest timestamp (if it exists)
     pub fn latest_block(&self) -> eyre::Result<Option<Block>> {
         match self.latest_block_header()? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,11 @@ async fn populate_db(opts: &Opts, db: &mut Database) -> eyre::Result<()> {
         (Some(block), None) => {
             Ok(db.add_block(&client.block(block.into()).await?)?)
         }
-        (None, Some(tx)) => {
+        (None, Some(tx_hash)) => {
+            let tx = client.transaction(tx_hash).await?;
             /* recall that we *must* have at least one *block* in the db at all times */
-            db.add_block(
-                &client
-                    .block(alloy::eips::BlockNumberOrTag::Latest.into())
-                    .await?,
-            )?;
-            db.add_transaction(&client.transaction(tx).await?)
+            db.add_block(&client.block(tx.block_hash.unwrap().into()).await?)?;
+            Ok(())
         }
         _ => Ok(db.add_block(
             &client

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,6 +46,8 @@ pub fn run(
         app.selected_block = db.block_by_hash(specified_block_hash)?.unwrap();
     } else if let Some(specified_tx) = transaction {
         app.view = View::Transaction;
+        app.selected_block =
+            db.block_by_transaction_hash(specified_tx)?.unwrap();
         app.selected_transaction = db.transaction(specified_tx)?.unwrap();
     }
 


### PR DESCRIPTION
# Issue
Closes #20.

# Changes
 
 - Add block lookup from transaction hash to the database
 - Enforce selected block when transaction is specified

![2025-01-23-091734_1920x1200_scrot](https://github.com/user-attachments/assets/74b8782f-cd84-40a9-bab5-8ace9d2db10c)

