### PR TITLE
Add libMEV support for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The default invocation (i.e., `blocktop`) will open the TUI and start retrieving
 | `q`, `Ctrl+c` | Exits the application |
 | `Esc` | Returns to the previous page or exits the application if on the main page |
 | `r` | Toggles the address display mode (i.e., labelled or raw) |
+| `l` | In block view, opens the block in [libMEV](https://libmev.com) |
 
 ### Headless Mode ###
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -19,7 +19,8 @@ use crate::{
     db::Database,
     utils::{
         self, etherscan_block_url, etherscan_transaction_url, grab_range,
-        label_address, to_ether, to_gwei, useful_gas_price, BuilderIdentity,
+        label_address, libmev_block_url, to_ether, to_gwei, useful_gas_price,
+        BuilderIdentity,
     },
 };
 
@@ -113,6 +114,16 @@ impl App {
                 if c == 'e' {
                     webbrowser::open(
                         etherscan_block_url(
+                            self.selected_block.clone().header.number,
+                        )
+                        .as_str(),
+                    )
+                    .unwrap()
+                }
+
+                if c == 'l' {
+                    webbrowser::open(
+                        libmev_block_url(
                             self.selected_block.clone().header.number,
                         )
                         .as_str(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,6 +144,14 @@ impl From<Bytes> for BuilderIdentity {
     }
 }
 
+/// Given a block number, produce the libMEV [`Url`] for the corresponding
+/// block (see <https://libmev.com>)
+pub fn libmev_block_url(block_number: u64) -> Url {
+    format!("https://libmev.com/blocks/{block_number}")
+        .parse()
+        .expect("invariant violated: constructed invalid block URL")
+}
+
 /// Given a block number, produce the Etherscan [`Url`] for the corresponding
 /// block
 pub fn etherscan_block_url(block_number: u64) -> Url {


### PR DESCRIPTION
# Issue
Closes #24.

# Changes
 - `l` in block view opens in the block in [the libMEV explorer](https://libmev.com)

(This works much the same internally as the existing Open-in-Etherscan feature).